### PR TITLE
Fix configure failing for Tcl

### DIFF
--- a/Tcl/configure
+++ b/Tcl/configure
@@ -3219,7 +3219,7 @@ else
 	# results, and the version is kept in special file).
     
 	if test -r /etc/.relid -a "X`uname -n`" = "X`uname -s`" ; then
-	    system=MP-RAS-`awk '{print $3}' /etc/.relid'`
+	    system=MP-RAS-`awk '{print $3}' /etc/.relid`
 	fi
 	if test "`uname -s`" = "AIX" ; then
 	    system=AIX-`uname -v`.`uname -r`


### PR DESCRIPTION
There is an extra quote in Tcl/configure that was causing an error during ./configure.  Tested by building on Linux