### PR TITLE
Fix two compiler warnings

### DIFF
--- a/Extensions/posix.c
+++ b/Extensions/posix.c
@@ -25,6 +25,7 @@
  
 
 #include <stk.h>
+#include <sys/wait.h>
 #include <sys/types.h>
 #include <sys/utsname.h>
 

--- a/Src/extend.c
+++ b/Src/extend.c
@@ -169,7 +169,7 @@ void STk_Cpointer_display(SCM obj, SCM port, int mode)
  ******************************************************************************/
 
 static Tcl_HashTable Cvars;
-static C_hash_table_initialized = 0;
+static int C_hash_table_initialized = 0;
 
 struct get_n_set_box {
   SCM (*getter)();


### PR DESCRIPTION
Hi @egallesio !
I know STk is not being developed anymore, but I thought I'd send a PR, just to fix two compilation warnings.

There are also others about unused variables, but I thought the unused variables could be historically important (because they show that there was the intention to do something, or they show that some previous version had something...) So I didn't remove them.